### PR TITLE
Fix module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/shiftkey/haproxy-spoe-go/fork
+module github.com/shiftkey/haproxy-spoe-go
 
 go 1.19
 


### PR DESCRIPTION
After this, you should be able to pull the package with: `go get github.com/shiftkey/haproxy-spoe-go@forked-package`. Right now, I'm getting this error: 

``` 
sh$ go get github.com/shiftkey/haproxy-spoe-go@forked-package
go: downloading github.com/shiftkey/haproxy-spoe-go v1.0.6-0.20250307171343-4494e15f180e
go: github.com/shiftkey/haproxy-spoe-go@forked-package (v1.0.6-0.20250307171343-4494e15f180e) requires github.com/shiftkey/haproxy-spoe-go@v1.0.6-0.20250307171343-4494e15f180e: parsing go.mod:
	module declares its path as: github.com/shiftkey/haproxy-spoe-go/fork
	        but was required as: github.com/shiftkey/haproxy-spoe-go
```